### PR TITLE
nest lost rake tasks together

### DIFF
--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -33,64 +33,66 @@ namespace :selector_reports do
           ) 
     puts bibview.title
   end 
-      
-  desc "reset db"
-  task:reset_db => :environment do
-    Rake::Task['db:reset'].execute
-  end
 
-  desc "Get status'p' records"
-  task:get_status_p => :reset_db do
-    
-    p = ItemView.where("item_status_code = 'p'")
-    p.each do |i|
-      unless i.record_metadata.record_last_updated_gmt > @minus3months || i.bib_views.first.cataloging_date_gmt.nil? || i.bib_views.first.bcode3 == 's'
-        lmlo_create(i) 
+  namespace :losts do
+    desc "drop losts table"
+    task:drop_losts => :environment do
+      Lost.delete_all
+    end
+  
+    desc "Get status'p' records"
+    task:get_status_p => :drop_losts do
+      
+      p = ItemView.where("item_status_code = 'p'")
+      p.each do |i|
+        unless i.record_metadata.record_last_updated_gmt > @minus3months || i.bib_views.first.cataloging_date_gmt.nil? || i.bib_views.first.bcode3 == 's'
+          lmlo_create(i) 
+        end
       end
     end
-  end
-
-  desc "Get status 'l' item records"
-  task:get_status_l => :get_status_p do
-    l = ItemView.where("item_status_code = 'l'")
-    l.each do |i|
-      unless i.record_metadata.record_last_updated_gmt > @minus1year
+  
+    desc "Get status 'l' item records"
+    task:get_status_l => :get_status_p do
+      l = ItemView.where("item_status_code = 'l'")
+      l.each do |i|
+        unless i.record_metadata.record_last_updated_gmt > @minus1year
+          lmlo_create(i)
+        end
+      end
+    end
+  
+    desc "Get status '$' item records"
+    task:get_status_dollar => :get_status_l do
+      dollar = ItemView.where("item_status_code = '$'")
+      dollar.each do |i|
         lmlo_create(i)
       end
     end
-  end
-
-  desc "Get status '$' item records"
-  task:get_status_dollar => :get_status_l do
-    dollar = ItemView.where("item_status_code = '$'")
-    dollar.each do |i|
-      lmlo_create(i)
+  
+    desc "Get status 'z' item records"
+    task:get_status_z => :get_status_dollar do
+      z = ItemView.where("item_status_code = 'z'")
+      z.each do |i|
+        lmlo_create(i)
+      end
     end
-  end
-
-  desc "Get status 'z' item records"
-  task:get_status_z => :get_status_dollar do
-    z = ItemView.where("item_status_code = 'z'")
-    z.each do |i|
-      lmlo_create(i)
+  
+    desc "Get status 'x' item records"
+    task:get_status_x => :get_status_z do
+      x = ItemView.where("item_status_code = 'x'")
+      x.each do |i|
+        lmlo_create(i)
+      end
+    end 
+  
+    desc "run all losts"
+    task :run_all => [
+      :drop_losts,
+      :get_status_p, 
+      :get_status_l, 
+      :get_status_dollar, 
+      :get_status_z, 
+      :get_status_x] do
     end
-  end
-
-  desc "Get status 'x' item records"
-  task:get_status_x => :get_status_z do
-    x = ItemView.where("item_status_code = 'x'")
-    x.each do |i|
-      lmlo_create(i)
-    end
-  end 
-
-  desc "run all"
-  task :runall => [
-    :reset_db,
-    :get_status_p, 
-    :get_status_l, 
-    :get_status_dollar, 
-    :get_status_z, 
-    :get_status_x] do
   end
 end


### PR DESCRIPTION
Added nested namespace for lost rake tasks. 

Also change lost:db:reset rake task to simply drop _lost_ table rather than resetting the whole db. I think this is desirable since we plan to have multiple tables/workflows in the app.
One issue with the commit is that the index is not reset; when the _lost_ db is refreshed, the ID count increments from last record number (rather than zero).

There is an approach to extend active record base class with a method to reset the id but I've never changed rails built-ins, wondering what you think:
http://stackoverflow.com/questions/2097052/rails-way-to-reset-seed-on-id-field

Resolves #28
