### PR TITLE
Issue 218

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Selector type allows users to submit and edit orders.
 Assistant type is a delegate account, tied to a selector, allowing the user to submit and edit orders to be reviewed and approved by assigned selector.
 
 ```ruby
-@user = Assistant.new(:email => 'test@example.com', :password => 'password', :password_confirmation => 'password', selector_id = 1)
+@user = Assistant.new(:email => 'test@example.com', :password => 'password', :password_confirmation => 'password', :selector_id => 1)
 
 @user.save
 
@@ -42,3 +42,17 @@ Admin type is for Acquisitions staff to review and process the orders.
 @user.save
 
 ```
+
+Updating a user
+```ruby
+u = User.find(idnumber)
+
+u.update_attributes(attribute: value)
+
+u.save
+```
+
+Listing user info
+```ruby
+y User.all
+````

--- a/README.md
+++ b/README.md
@@ -56,3 +56,18 @@ Listing user info
 ```ruby
 y User.all
 ````
+
+=====================================================================================================
+Search and Index
+
+Sunspot is used to provide interaction with Solr. [Sunspot Docs](https://github.com/sunspot/sunspot)
+
+When installing, run 
+```
+bundle exec rake sunspot:solr:start
+```
+
+When updating the searchable definition in a model, be sure to reindex:
+```
+bundle exec rake sunspot:solr:reindex
+```

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -46,15 +46,19 @@ class OrdersController < ApplicationController
     @order = Order.new(attributes)
     @user = current_user
     @order.user_id = @user.id
-    if @order.save
-      unless @user.instance_of? Assistant
-        @order.approve_selection!
-        @order.save
-      end
+    #for the creation of provisional orders
+    if @order.save and @user.instance_of? Assistant
+      OrderMailer.provisional_order(@order).deliver
+      @order.save
+    #for the creation of all other orders
+    elsif @order.save
+      @order.approve_selection!
       OrderMailer.new_order(@order).deliver
+      @order.save
     end
     respond_with(@order)
   end
+
 
   def update
    
@@ -111,6 +115,9 @@ class OrdersController < ApplicationController
     @order.approve_selection!
     @order.save
     respond_with(@order)
+    #add call to mailer here
+    OrderMailer.new_order(@order).deliver
+
   end
 
   def provisional

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -49,7 +49,6 @@ class OrdersController < ApplicationController
     #for the creation of provisional orders
     if @order.save and @user.instance_of? Assistant
       OrderMailer.provisional_order(@order).deliver
-      @order.save
     #for the creation of all other orders
     elsif @order.save
       @order.approve_selection!

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -48,26 +48,25 @@ class OrdersController < ApplicationController
     @order = Order.new(attributes)
     @user = current_user
     @order.user_id = @user.id
-    #for creation of provisional rush orders
-    if @order.save and @user.instance_of? Assistant and @order.rush_order
-      @subj = "RUSH Provisional Tricerashopper Order Request Confirmation"
-      OrderMailer.provisional_order(@order, @subj).deliver
-      @order.save
-    #for the creation of provisional orders
-    elsif @order.save and @user.instance_of? Assistant
-      @subj = "Provisional Tricerashopper Order Request Confirmation'"
+    #for creation of provisional rush orders and regular provisional orders
+    if @order.save and @user.instance_of? Assistant 
+      if @order.rush_order
+        @subj = "[tricera] RUSH Provisional Order Confirmation"
+      else
+        @subj = "[tricera] Provisional Order Confirmation"
+      end
       OrderMailer.provisional_order(@order, @subj).deliver
       @order.save
     #for creation of approved rush orders
     elsif @order.save and @order.rush_order
       @order.approve_selection!
-      @subj = "RUSH Tricerashopper Order Request Confirmation"
+      @subj = "[tricera] RUSH Order Confirmation"
       OrderMailer.new_order(@order, @subj).deliver
       @order.save
     #for the creation of all other orders
     elsif @order.save
       @order.approve_selection!
-      @subj = "Tricerashopper Order Request Confirmation'"
+      @subj = "[tricera] Order Request Confirmation"
       OrderMailer.new_order(@order, @subj).deliver
       @order.save
     end
@@ -130,12 +129,12 @@ class OrdersController < ApplicationController
     @order.approve_selection!
     @order.save
     respond_with(@order)
-    @subj = "Approved Tricerashopper Order Confirmation"
+    if @order.rush_order
+      @subj = "[tricera] RUSH Approved Order Confirmation"
+    else
+      @subj = "[tricera] Approved Order Confirmation"
+    end
     OrderMailer.new_order(@order, @subj).deliver
-
-  end
-
-  def provisional
   end
 
   def export_to_marc

--- a/app/mailers/order_mailer.rb
+++ b/app/mailers/order_mailer.rb
@@ -3,14 +3,14 @@ class OrderMailer < ActionMailer::Base
   add_template_helper(OrdersHelper)
 
   #change bcc to cc in mailer for testing
-  def new_order(order)
+  def new_order(order, subj)
       @order = order
-      mail(to: @order.selector, bcc: Admin.pluck(:email), subject: 'Tricerashopper Order Request Confirmation')
+      mail(to: @order.selector, bcc: Admin.pluck(:email), subject: subj)
   end
 
-   def provisional_order(order)
+   def provisional_order(order, subj)
       @order = order
-      mail(to: @order.selector, subject: 'Provisional Tricerashopper Order Request Confirmation')
+      mail(to: @order.selector, subject: subj)
   end
  
   def rejected_order(order)

--- a/app/mailers/order_mailer.rb
+++ b/app/mailers/order_mailer.rb
@@ -2,9 +2,15 @@ class OrderMailer < ActionMailer::Base
   default from: "NO-REPLY@lucy.libraries.uc.edu"
   add_template_helper(OrdersHelper)
 
+  #change bcc to cc in mailer for testing
   def new_order(order)
       @order = order
-      mail(to: @order.selector, bcc: Admin.pluck(:email), subject: 'Tricerashopper Order Request Confirmation')
+      mail(to: @order.selector, cc: Admin.pluck(:email), subject: 'Tricerashopper Order Request Confirmation')
+  end
+
+   def provisional_order(order)
+      @order = order
+      mail(to: @order.selector, subject: 'Provisional Tricerashopper Order Request Confirmation')
   end
  
   def rejected_order(order)

--- a/app/mailers/order_mailer.rb
+++ b/app/mailers/order_mailer.rb
@@ -5,7 +5,7 @@ class OrderMailer < ActionMailer::Base
   #change bcc to cc in mailer for testing
   def new_order(order)
       @order = order
-      mail(to: @order.selector, cc: Admin.pluck(:email), subject: 'Tricerashopper Order Request Confirmation')
+      mail(to: @order.selector, bcc: Admin.pluck(:email), subject: 'Tricerashopper Order Request Confirmation')
   end
 
    def provisional_order(order)

--- a/app/mailers/order_mailer.rb
+++ b/app/mailers/order_mailer.rb
@@ -15,12 +15,12 @@ class OrderMailer < ActionMailer::Base
  
   def rejected_order(order)
       @order = order
-      mail(to: @order.selector, subject: 'Tricerashopper Order Rejected')
+      mail(to: @order.selector, subject: '[tricera] Order Rejected')
   end
 
   def ordered_order(order)
       @order = order
-      mail(to: @order.selector, subject: 'Tricerashopper Order Completed')
+      mail(to: @order.selector, subject: '[tricera] Order Completed')
   end
 
 

--- a/app/mailers/order_mailer.rb
+++ b/app/mailers/order_mailer.rb
@@ -15,12 +15,12 @@ class OrderMailer < ActionMailer::Base
  
   def rejected_order(order)
       @order = order
-      mail(to: @order.selector, subject: '[tricera] Order Rejected')
+      mail(to: @order.selector, subject: '[tricerashopper] Order Rejected')
   end
 
   def ordered_order(order)
       @order = order
-      mail(to: @order.selector, subject: '[tricera] Order Completed')
+      mail(to: @order.selector, subject: '[tricerashopper] Order Completed')
   end
 
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -24,6 +24,7 @@ class Order < ActiveRecord::Base
     integer :user_id
     date :created_at
     integer :id
+    string :rush_order
   end
 
   workflow do 

--- a/app/views/order_mailer/provisional_order.erb
+++ b/app/views/order_mailer/provisional_order.erb
@@ -1,0 +1,40 @@
+<%- model_class = Order -%>
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h4>Provisional Order Request Confirmation</h4>
+    <p>Your order request has been submitted for review.</p>
+    <p>
+    <table style="width:75%">
+      <tr>
+        <td><strong><%= model_class.human_attribute_name(:author) %>:</strong></td>
+        <td><%= @order.author %></td>
+      </tr>
+      <tr>  
+        <td><strong><%= model_class.human_attribute_name(:title) %>:</strong></td>
+        <td><%= @order.title %></td>
+      </tr>
+      <tr>
+        <td><strong><%= model_class.human_attribute_name(:publisher) %>:</strong></td>
+        <td><%= @order.publisher %></td>
+      </tr>
+      <tr>
+        <td><strong><%= model_class.human_attribute_name(:isbn) %>:</strong></td>
+        <td><%= @order.isbn %></td>
+      </tr>
+      <tr>
+        <td><strong><%= model_class.human_attribute_name(:fund) %>:</strong></td>
+        <td><%= @order.fund %></td>
+      </tr>
+      <tr>
+        <td><strong><%= model_class.human_attribute_name(:cost) %>:</strong></td>
+        <td><%= number_to_currency(cost_in_dollars(@order.cost), unit: "#{@order.currency} ") %></td>
+      </tr>
+    </table>
+    </p>
+    <p><%= link_to order_url(@order), order_url(@order) %></p>
+  </body>
+</html>

--- a/app/views/orders/_facets.html.erb
+++ b/app/views/orders/_facets.html.erb
@@ -5,10 +5,25 @@
       <h4>Status</h4>
         <% for row in @search.facet(:workflow_state).rows %>
           <li>
-            <% if params[:state].blank? %>
+            <% if not params[:rush].blank? and params[:state].blank? %>
+                <% %>
+                <!-- if user has clicked on rush, do nothing -->
+            <% elsif params[:state].blank? %>
               <%= link_to model_class.human_attribute_name(row.value), state: row.value %>
             <% else %>
               <%= link_to "#{model_class.human_attribute_name(row.value)} (remove)", request.params.merge({state: nil, page: nil}) %> 
+            <% end %>
+          </li>
+        <% end %>
+        <% for row in @search.facet(:rush_order).rows %>
+         <li>
+            <% if params[:rush].blank? and not params[:state].blank? %>
+                <% %>
+                <!-- if user has clicked on an order status, do nothing -->
+            <% elsif params[:rush].blank? %>
+              <%= link_to model_class.human_attribute_name("rush"), rush: row.value %>
+            <% else %>
+              <%= link_to "#{model_class.human_attribute_name("rush")} (remove)", request.params.merge({rush: nil, page: nil}) %> 
             <% end %>
           </li>
         <% end %>


### PR DESCRIPTION
Added rush facet. Working in all 3 account types. 
Had to replace @order.save in lines 55 and 60 for provisional orders because controller would not allow the state to be changed from provisional to approved. It said it was trying to call the state change on a null object. 

Changed mailer to add RUSH to subject line of rush orders. This required moving the email subject from the mailer to the controller. Now the subject is passed to the mailer as a parameter to allow for different subject lines for different cases. 

Cases are:
Assistant + rush order = rush provisional confirmation to selector & assistant
Assistant + non-rush order = provisional confirmation to selector & assistant

Selector + non-rush order = regular confirmation to admin & selector
Selector + rush order = rush confirmation to admin & selector
Selector + approval of provisional order = approval confirmation to admin & selector
Resolves #218 etc
